### PR TITLE
change DME to "durable medical equipment"

### DIFF
--- a/encounter_type.csv
+++ b/encounter_type.csv
@@ -4,7 +4,7 @@ ambulance
 ambulatory surgical center
 assisted living facility
 dialysis
-DME
+durable medical equipment
 emergency department
 home health
 hospice


### PR DESCRIPTION
I propose writing out the full "durable medical equipment" for consistency with how we do it for every other encounter type.