### PR TITLE
change a column name to be consistent with other terminology files

### DIFF
--- a/terminology/admit_type.csv
+++ b/terminology/admit_type.csv
@@ -1,4 +1,4 @@
-admit_type_code,description
+code,description
 1,Emergency
 2,Urgent
 3,Elective


### PR DESCRIPTION
Changed the name of the column 'admit_type_code' to 'code' in the file 'admit_type.csv'. This makes it consistent with other files, e.g. with 'admit_source.csv'.